### PR TITLE
Change default kubemark image to replace non existing image

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	var enableLeaderElection bool
 	var kubemarkImage string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&kubemarkImage, "kubemark-image", "gcr.io/cf-london-servces-k8s/bmo/kubemark", "The location of the kubemark image")
+	flag.StringVar(&kubemarkImage, "kubemark-image", "quay.io/elmiko/kubemark", "The location of the kubemark image")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")


### PR DESCRIPTION
Currently `gcr.io/cf-london-servces-k8s/bmo/kubemark` image being used to start Kubemark but since this image is not present Kubemark do not start.

Replacing this non existent image with the `gcr.io/cf-london-servces-k8s/bmo/kubemark` 