### PR TITLE
add CGO_ENABLED=0 to publish-kubemark-images

### DIFF
--- a/hack/tools/publish-kubemark-images.go
+++ b/hack/tools/publish-kubemark-images.go
@@ -112,7 +112,7 @@ func (p *PublishImages) dockerBuild(v *semver.Version) error {
 		return err
 	}
 
-	cmd = exec.Command("make", "-C", p.KubeDir, "clean", "all", "WHAT=cmd/kubemark")
+	cmd = exec.Command("make", "-C", p.KubeDir, "clean", "all", "WHAT=cmd/kubemark", "CGO_ENABLED=0")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
this will ensure that none of the resulting images won't have a shared library
build, which will cause issues when booting the resulting images.