### PR TITLE
Remove ncdc from owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -17,6 +17,5 @@ aliases:
   cluster-api-maintainers:
   - justinsb
   - detiber
-  - ncdc
   - vincepri
   - CecileRobertMichon


### PR DESCRIPTION
I'm no longer working on Cluster API and would like to remove myself from the maintainers list.