### PR TITLE
Add clusterctl settings and update release docs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@ The Kubernetes Template Project is released on an as-needed basis. The process i
 
 1. An issue is proposing a new release with a changelog since the last release
 1. All [OWNERS](OWNERS) must LGTM this release
+1. Before tagging a new release, ensure that the `metadata.yaml` and `clusterctl-settings.json` files are up to date
 1. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push $VERSION`
 1. The release issue is closed
 1. An announcement email is sent to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] kubernetes-template-project $VERSION is released`

--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -1,0 +1,8 @@
+{
+  "name": "infrastructure-kubemark",
+    "config": {
+      "componentsFile": "infrastructure-components.yaml",
+      "nextVersion": "v0.3.0"
+    }
+}
+


### PR DESCRIPTION
This change adds a `clusterctl-settings.json` fail to make configuring developer environments easier, see [this doc for more info][capi-doc]. It also adds a little more info the `RELEASE.md` file about updating the version sensitive developer files before tagging.

[capi-doc]: https://cluster-api.sigs.k8s.io/clusterctl/developers.html#available-providers