### PR TITLE
update kubernetes API types that are deprecated in 1.22

### DIFF
--- a/config/crd/patches/webhook_in_kubemarkmachinetemplates.yaml
+++ b/config/crd/patches/webhook_in_kubemarkmachinetemplates.yaml
@@ -1,6 +1,5 @@
 # The following patch enables conversion webhook for CRD
-# CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kubemarkmachinetemplates.infrastructure.cluster.x-k8s.io

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,13 +1,13 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader


### PR DESCRIPTION
Some of the API types are no longer served by kubernetes 1.22, this
change updates the kustomize configuration files to have the v1
versions.

The following types are updated from v1beta1 to v1:
* apiextensions.k8s.io CustomResourceDefinition
* admissionregistration.k8s.io MutatingWebhookConfiguration
* admissionregistration.k8s.io ValidatingWebhookConfiguration
* rbac.authorization.k8s.io ClusterRole