### PR TITLE
align manager flag names with upstream kube components

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,7 +26,7 @@ spec:
       - command:
         - /manager
         args:
-        - --enable-leader-election
+        - --leader-elect
         image: controller:latest
         name: manager
         resources:

--- a/main.go
+++ b/main.go
@@ -52,10 +52,10 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var kubemarkImage string
-	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-addr", ":8080", "The address the metric endpoint binds to.")
 	// TODO (elmiko) update the following default image link when we have a home for the kubemark images
 	flag.StringVar(&kubemarkImage, "kubemark-image", "quay.io/elmiko/kubemark", "The location of the kubemark image")
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()


### PR DESCRIPTION
Fixes #31 
Changes :
Renaming --metrics-addr to --metrics-bind-addr
Renaming --enable-leader-election to --leader-elect

as per - https://cluster-api.sigs.k8s.io/developer/providers/v0.3-to-v0.4.html#align-manager-flag-names-with-upstream-kubernetes-components