### PR TITLE
add github workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Tell us about a problem you are experiencing
+
+---
+
+**What steps did you take and what happened:**
+[A clear and concise description on how to REPRODUCE the bug.]
+
+
+**What did you expect to happen:**
+
+
+**Anything else you would like to add:**
+[Miscellaneous information that will assist in solving the issue.]
+
+
+**Environment:**
+
+- cluster-api version: 
+- cluster-api-provider-kubemark version: 
+- Kubernetes version: (use `kubectl version`): 
+- OS (e.g. from `/etc/os-release`):
+
+/kind bug
+[One or more /area label. See https://github.com/kubernetes-sigs/cluster-api-provider-kubemark/labels?q=area for the list of labels]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+i---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+<!-- NOTE: ⚠️ For larger proposals, we follow the CAEP process as outlined in https://sigs.k8s.io/cluster-api/CONTRIBUTING.md. -->
+
+**User Story**
+
+As a [developer/user/operator] I would like to [high level description] for [reasons]
+
+**Detailed Description**
+
+[A clear and concise description of what you want to happen.]
+
+**Anything else you would like to add:**
+
+[Miscellaneous information that will assist in solving the issue.]
+
+/kind feature

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,4 @@
-i---
+---
 name: Feature request
 about: Suggest an idea for this project
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!-- Thanks for sending a pull request! -->
+
+**What this PR does / why we need it**:
+
+**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
+
+**Special notes for your reviewer**:
+
+**Release notes**:
+<!--  Steps to write your release note:
+1. Use the release-note-* labels to set the release note state (if you have access)
+2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
+-->
+```release-note
+```

--- a/.github/workflows/image_build.yaml
+++ b/.github/workflows/image_build.yaml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches:
+      - "main"
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: build image
+        shell: bash
+        env:
+          QUAY_TOKEN: ${{secrets.QUAY_TOKEN}}
+          REGISTRY: "quay.io/cluster-api-provider-kubemark"
+          TAG: "latest"
+        run: |
+          echo $QUAY_TOKEN | docker login -u="cluster-api-provider-kubemark+capk_robot" quay.io --password-stdin
+          make docker-build
+          make docker-push

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,30 @@
+on: [push, pull_request]
+name: build
+jobs:
+  unit_test:
+    if: (github.repository == 'kubernetes-sigs/cluster-api-provider-kubemark')
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Test
+      run: make test
+    - name: Build
+      run: make manager
+
+  go-linter:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with: # TODO: remove this when the deprecated function will be removed (issue #85)
+        args: --exclude SA1019 --timeout=5m


### PR DESCRIPTION
This addresses issue https://github.com/kubernetes-sigs/cluster-api-provider-kubemark/issues/37

* Add templates for PRs and issues.
* Add workflows for PRs: 
- run tests
- push controller manager image to `quay.io/cluster-api-provider-kubemark`

Notes:
- we still need to add a secret `QUAY_TOKEN` to this repo (I don't seem to have access), I can provide the token
- I can grant access to `quay.io/cluster-api-provider-kubemark` org per request