### PR TITLE
update artifacts for capi v1.+ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ pretend to run pods scheduled to them. For more information on Kubemark, the
 [Kubemark developer guide][kubemark_docs] has more details.
 
 ## Getting started
+
+**Prerequisites**
+* Ubuntu Server 22.04
+* clusterctl v1.1.4
+
 At this point the Kubemark provider is extremely alpha. To deploy the Kubemark
 provider, you can add the latest release to your clusterctl config file, by
 default located at `~/.cluster-api/clusterctl.yaml`.
@@ -40,11 +45,9 @@ default located at `~/.cluster-api/clusterctl.yaml`.
 ```yaml
 providers:
 - name: "kubemark"
-  url: "https://github.com/kubernetes-sigs/cluster-api-provider-kubemark/releases/v0.3.0/infrastructure-components.yaml"
+  url: "https://github.com/kubernetes-sigs/cluster-api-provider-kubemark/releases/v0.4.0/infrastructure-components.yaml"
   type: "InfrastructureProvider"
 ```
-
-*Note: the `v0.3.0` release of the kubemark provider has been tested with the `v0.1.\*` versions of Cluster API*
 
 For demonstration purposes, we'll use the [CAPD][capd] provider. Other
 providers will also work, but CAPD is supported with a custom
@@ -61,16 +64,24 @@ Once initialized, you'll need to deploy your workload cluster using the `capd`
 flavor to get a hybrid CAPD/CAPK cluster:
 
 ```bash
-clusterctl config cluster wow --infrastructure kubemark --flavor capd --kubernetes-version 1.21.1 --control-plane-machine-count=1 --worker-machine-count=4 | kubectl apply -f-
+export SERVICE_CIDR="172.17.0.0/16"
+export POD_CIDR="192.168.122.0/24"
+clusterctl generate cluster wow --infrastructure kubemark --flavor capd --kubernetes-version 1.23.6 --control-plane-machine-count=1 --worker-machine-count=4 | kubectl apply -f-
 ```
 
+*Note: these CIDR values are specific to Ubuntu Server 22.04*
+
 You should see your cluster come up and quickly become available with 4 Kubemark machines connected to your CAPD control plane.
+
+To bring all the cluster nodes into a ready state you will need to deploy a CNI
+solution into the kubemark cluster. Please see the [Cluster API Book](https://cluster-api.sigs.k8s.io/user/quick-start.html?highlight=cni#deploy-a-cni-solution)
+for more information.
 
 For other providers, you can either create a custom hybrid cluster template, or deploy the control plane and worker machines separately, specifiying the same cluster name:
 
 ```bash
-clusterctl config cluster wow --infrastructure aws      --kubernetes-version 1.21.1 --control-plane-machine-count=1 | kubectl apply -f-
-clusterctl config cluster wow --infrastructure kubemark --kubernetes-version 1.21.1 --worker-machine-count=4        | kubectl apply -f-
+clusterctl generate cluster wow --infrastructure aws      --kubernetes-version 1.23.6 --control-plane-machine-count=1 | kubectl apply -f-
+clusterctl generate cluster wow --infrastructure kubemark --kubernetes-version 1.23.6 --worker-machine-count=4        | kubectl apply -f-
 ```
 
 ## Using tilt

--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -2,7 +2,8 @@
   "name": "infrastructure-kubemark",
     "config": {
       "componentsFile": "infrastructure-components.yaml",
-      "nextVersion": "v0.3.99"
+      "nextVersion": "v0.4.99",
+      "configFolder": "config"
     }
 }
 

--- a/config/manager/manager_image_patch.yaml
+++ b/config/manager/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/cf-london-servces-k8s/bmo/cluster-api-kubemark/cluster-api-kubemark-controller:dev
-        name: manager
+        - image: quay.io/cluster-api-provider-kubemark/cluster-api-kubemark-controller-amd64:latest
+          name: manager

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,3 +11,6 @@ releaseSeries:
   - major: 0
     minor: 3
     contract: v1beta1
+  - major: 0
+    minor: 4
+    contract: v1beta1

--- a/templates/cluster-template-capd.yaml
+++ b/templates/cluster-template-capd.yaml
@@ -46,11 +46,12 @@ metadata:
   namespace: "${NAMESPACE}"
 spec:
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
-  infrastructureTemplate:
-    kind: DockerMachineTemplate
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    name: "${CLUSTER_NAME}-control-plane"
-    namespace: "${NAMESPACE}"
+  machineTemplate:
+    infrastructureRef:
+      kind: DockerMachineTemplate
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      name: "${CLUSTER_NAME}-control-plane"
+      namespace: "${NAMESPACE}"
   kubeadmConfigSpec:
     clusterConfiguration:
       controllerManager:
@@ -60,11 +61,15 @@ spec:
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
-        kubeletExtraArgs: {eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'}
+        kubeletExtraArgs:
+          cgroup-driver: cgroupfs
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
     joinConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock
-        kubeletExtraArgs: {eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'}
+        kubeletExtraArgs:
+          cgroup-driver: cgroupfs
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
   version: "${KUBERNETES_VERSION}"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -109,7 +114,12 @@ metadata:
   namespace: default
 spec:
   template:
-    spec: {}
+    spec:
+      extraMounts:
+        - name: containerd-sock
+          containerPath: /run/containerd/containerd.sock
+          hostPath: /run/containerd/containerd.sock
+          type: Socket
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -1,7 +1,7 @@
 {
   "name": "kubemark",
   "config": {
-    "image": "gcr.io/cf-london-servces-k8s/bmo/cluster-api-kubemark/cluster-api-kubemark-controller",
+    "image": "quay.io/cluster-api-provider-kubemark/cluster-api-kubemark-controller-amd64:latest",
     "live_reload_deps": [
       "main.go",
       "go.mod",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

this changes updates several configuration files to be in line with the
latest cluster api tooling.
    
* update configFolder in clusterctl-settings.json so that developer
  create-local-repository.py script works from cluster-api
* update the controller image location to the new quay.io spec so that a
  default install of capk using `clusterctl init` will work
* update the manifest template for the capd example control plane to
  match the latest API from cluster-api
* update commands in readme to match latest from cluster-api


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
