### PR TITLE
Adds -profiler-address flag and fixes kustomization for tilt compatibility

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,13 +1,16 @@
 # Adds namespace to all resources.
 namespace: capk-system
 
+namePrefix: capk-
+
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  cluster.x-k8s.io/provider: "infrastructure-kubemark"
 
 bases:
 - ../rbac
 - ../manager
+- ../crd
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,9 +1,3 @@
-namePrefix: capk-
-
-commonLabels:
-  cluster.x-k8s.io/provider: "infrastructure-kubemark"
-
 bases:
-- crd
 # - webhook # Disable this if you're not using the webhook functionality.
 - default

--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -1,17 +1,20 @@
-{
-  "name": "kubemark",
-  "config": {
-    "image": "quay.io/cluster-api-provider-kubemark/cluster-api-kubemark-controller-amd64:latest",
-    "live_reload_deps": [
-      "main.go",
-      "go.mod",
-      "go.sum",
-      "api",
-      "cmd",
-      "controllers",
-      "pkg",
-      "exp",
-      "util"
-    ]
+[
+  {
+    "name": "kubemark",
+    "config": {
+      "image": "quay.io/cluster-api-provider-kubemark/cluster-api-kubemark-controller-amd64:latest",
+      "live_reload_deps": [
+        "main.go",
+        "go.mod",
+        "go.sum",
+        "api",
+        "cmd",
+        "controllers",
+        "pkg",
+        "exp",
+        "util"
+      ],
+      "label": "CAPK"
+    }
   }
-}
+]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This changes allow capk to work with CAPIs Tiltfile.

* Changes required because CAPI's Tiltfile runs `kustomize` to `config/default`:
  * Moves the provider label in from `config/kustomization.yaml` to `config/default`
  * Moves the crd directory reference from `config/kustomization.yaml` to `config/default`
  * Moves the name-prefix setting from `config/kustomization.yaml` to `config/default`
* Adds pprof flag `--profiler-address` to `main.go`, CAPI's Tiltfile enforces the `--profiler-address` flag
* Converts the `tilt-provider.json` to an array

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```
