### PR TITLE
update configs for release 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ default located at `~/.cluster-api/clusterctl.yaml`.
 ```yaml
 providers:
 - name: "kubemark"
-  url: "https://github.com/kubernetes-sigs/cluster-api-provider-kubemark/releases/v0.4.0/infrastructure-components.yaml"
+  url: "https://github.com/kubernetes-sigs/cluster-api-provider-kubemark/releases/v0.5.0/infrastructure-components.yaml"
   type: "InfrastructureProvider"
 ```
 

--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -2,7 +2,7 @@
   "name": "infrastructure-kubemark",
     "config": {
       "componentsFile": "infrastructure-components.yaml",
-      "nextVersion": "v0.4.99",
+      "nextVersion": "v0.5.99",
       "configFolder": "config"
     }
 }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,3 +14,6 @@ releaseSeries:
   - major: 0
     minor: 4
     contract: v1beta1
+  - major: 0
+    minor: 5
+    contract: v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the metadata configuration for a new 0.5.0 release. after merging we will add a tag on this commit to denote the release.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #61
