### PR TITLE
add default container annotations to manager pod

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,6 +19,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: "manager"
       labels:
         control-plane: capk-controller-manager
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

as described in the well known labels and annotations documentation[0], the `default-container` label is a convenience that makes commands like `kubectl logs` use a specific container by default. as the manager is usually more interesting than the kube-proxy container, this pr sets the value.

[0]
https://kubernetes.io/docs/reference/labels-annotations-taints/#kubectl-kubernetes-io-default-container

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
* controller manager pod is annotated for the manager as the default container
```
