### PR TITLE
remove deprecated flags from kubemark command

### DIFF
--- a/controllers/kubemarkmachine_controller.go
+++ b/controllers/kubemarkmachine_controller.go
@@ -333,8 +333,6 @@ func (r *KubemarkMachineReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	kubemarkArgs := []string{
 		"--v=3",
 		"--morph=kubelet",
-		"--log-file=/var/log/kubelet.log",
-		"--logtostderr=false",
 		fmt.Sprintf("--name=%s", kubemarkMachine.Name),
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

this change updates the kubemark deployment to not use the deprecated logging commands. these were deprecated in 1.23, and do not exist in 1.26, causing issues starting the kubemark containers.

see
[KEP-2845](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md) for more information.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #71 

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
* removed --log-file and --logtostderr flags from kubemark command  in kubemark machine pods
```
