### PR TITLE
update default kubemark image repository

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,8 +130,7 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
 
-	// TODO (elmiko) update the following default image link when we have a home for the kubemark images
-	flag.StringVar(&kubemarkImage, "kubemark-image", "quay.io/elmiko/kubemark",
+	flag.StringVar(&kubemarkImage, "kubemark-image", "quay.io/cluster-api-provider-kubemark/kubemark",
 		"The location of the kubemark image")
 
 	flags.AddTLSOptions(fs, &tlsOptions)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

this change migrates the default repository for the deployed kubemark image from my personal quay account to the cluster-api-provider-kubemark organization account.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
