### PR TITLE
add cert-manager version to test config

### DIFF
--- a/hack/tests/Makefile
+++ b/hack/tests/Makefile
@@ -114,6 +114,7 @@ CLUSTERCTL_CONFIG_PATH := $(HOME)/.cluster-api
 
 define LOCAL_REPOSITORY_PATCH
 cert-manager:
+  version: "$(CERT_MANAGER_VERSION)"
   url: "$(ROOT_DIR)/hack/tests/resources/cert-manager/$(CERT_MANAGER_VERSION)/cert-manager.yaml"
 images:
   all:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

this change adds the cert-manager version to the test configuration for cluster-api. we carry the cert-manager manifest and version along with our tests so that the local docker registry can be populated with the images from the upstream cert-manager project instead of having the images pull when the clusterctl init command runs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
