### PR TITLE
update calico link in test makefile

### DIFF
--- a/hack/tests/Makefile
+++ b/hack/tests/Makefile
@@ -179,7 +179,7 @@ $(CLUSTERCTL_BIN): .ensure-capi-path
 .tenant-cluster-info:
 	@echo "\nTenant cluster is ready!"
 	@echo "\nYou can access tenant cluster with the above kubeconfig. (It also can be found in '/tmp/km.kubeconfig')"
-	@echo "\nFor CNI, you may apply calico with 'kubectl --kubeconfig /tmp/km.kubeconfig apply -f https://docs.projectcalico.org/v3.20/manifests/calico.yaml'"
+	@echo "\nFor CNI, you may apply calico with 'kubectl --kubeconfig /tmp/km.kubeconfig apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.24.1/manifests/calico.yaml'"
 
 .PHONY: test-e2e
 test-e2e:	.start-kind-cluster \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

this change updates the printed guidance about which calico manifest to use for starting a CNI on the deployed kubemark cluster. the previous version was giving warnings about the version level for PDBs because kubernetes has since deprecated the v1beta1 version.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
