### PR TITLE
change module name to sigs.k8s.io/cluster-api-provider-kubemark

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,7 @@ linters-settings:
       - '^ \+.*'
       - '^ ANCHOR.*'
   gci:
-    local-prefixes: "sigs.k8s.io/kubernetes-sigs/cluster-api-provider-kubemark"
+    local-prefixes: "sigs.k8s.io/cluster-api-provider-kubemark"
   importas:
     no-unaliased: true
     alias:

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ test-e2e: ## Launch integration e2e test with building images (for local usage)
 
 .PHONY: manager
 manager: ## Build manager binary
-	go build -o $(BIN_DIR)/manager sigs.k8s.io/kubernetes-sigs/cluster-api-provider-kubemark
+	go build -o $(BIN_DIR)/manager sigs.k8s.io/cluster-api-provider-kubemark
 
 $(CONTROLLER_GEN): $(TOOLS_DIR)/go.mod # Build controller-gen from tools folder.
 	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/controller-gen sigs.k8s.io/controller-tools/cmd/controller-gen

--- a/controllers/kubemarkmachine_controller.go
+++ b/controllers/kubemarkmachine_controller.go
@@ -57,7 +57,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	infrav1 "sigs.k8s.io/kubernetes-sigs/cluster-api-provider-kubemark/api/v1alpha4"
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubemark/api/v1alpha4"
 )
 
 const (

--- a/controllers/kubemarkmachine_controller_test.go
+++ b/controllers/kubemarkmachine_controller_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	infrav1 "sigs.k8s.io/kubernetes-sigs/cluster-api-provider-kubemark/api/v1alpha4"
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubemark/api/v1alpha4"
 )
 
 const (

--- a/controllers/kubemarkmachinetemplate_controller.go
+++ b/controllers/kubemarkmachinetemplate_controller.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
-	infrav1 "sigs.k8s.io/kubernetes-sigs/cluster-api-provider-kubemark/api/v1alpha4"
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubemark/api/v1alpha4"
 )
 
 // KubemarkMachineTemplateReconciler reconciles a KubemarkMachineTemplate objects.

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -19,7 +19,7 @@ package controllers
 import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	infrav1 "sigs.k8s.io/kubernetes-sigs/cluster-api-provider-kubemark/api/v1alpha4"
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubemark/api/v1alpha4"
 )
 
 const (

--- a/controllers/util_test.go
+++ b/controllers/util_test.go
@@ -22,7 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	infrav1 "sigs.k8s.io/kubernetes-sigs/cluster-api-provider-kubemark/api/v1alpha4"
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubemark/api/v1alpha4"
 )
 
 func TestGetKubemarkExtendedResources(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/kubernetes-sigs/cluster-api-provider-kubemark
+module sigs.k8s.io/cluster-api-provider-kubemark
 
 go 1.20
 

--- a/hack/publish-kubemark-images/go.mod
+++ b/hack/publish-kubemark-images/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/kubernetes-sigs/cluster-api-provider-kubemark/hack/publish-kubemark-images
+module sigs.k8s.io/cluster-api-provider-kubemark/hack/publish-kubemark-images
 
 go 1.19
 

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/kubernetes-sigs/cluster-api-provider-kubemark/hack/tools
+module sigs.k8s.io/cluster-api-provider-kubemark/hack/tools
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -43,8 +43,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
-	infrav1 "sigs.k8s.io/kubernetes-sigs/cluster-api-provider-kubemark/api/v1alpha4"
-	"sigs.k8s.io/kubernetes-sigs/cluster-api-provider-kubemark/controllers"
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubemark/api/v1alpha4"
+	"sigs.k8s.io/cluster-api-provider-kubemark/controllers"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

after looking at the other providers it appears that we inadvertently added a stutter to our module name. this change removes the "kubernetes-sigs" stutter in the module name.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Module name for this provider is now "sigs.k8s.io/cluster-api-provider-kubemark".
```
