### PR TITLE
update capd template to use 1.6 best practices

### DIFF
--- a/hack/tests/Makefile
+++ b/hack/tests/Makefile
@@ -23,7 +23,8 @@ KUBE_RBAC_PROXY_VERSION ?= v0.5.0
 KUBE_RBAC_IMAGE_REPOSITORY ?= quay.io/coreos
 KUBE_RBAC_PROXY ?= kube-rbac-proxy
 DEV_REGISTRY ?= localhost:5000
-CAPI_VERSION := v1.5.99
+CAPI_VERSION := v1.6.99
+XDG_CONFIG_HOME ?= $(HOME)/.config
 
 .start-kind-cluster:
 	@kind delete cluster; sleep 20; docker network create kind; $(TEST_DIR)/utils/kind-with-registry.sh

--- a/hack/tests/resources/docker-control-plane.yaml
+++ b/hack/tests/resources/docker-control-plane.yaml
@@ -53,19 +53,15 @@ spec:
         certSANs:
         - localhost
         - 127.0.0.1
+        - 0.0.0.0
+        - host.docker.internal
       controllerManager:
         extraArgs:
           enable-hostpath-provisioner: "true"
     initConfiguration:
-      nodeRegistration:
-        criSocket: /var/run/containerd/containerd.sock
-        kubeletExtraArgs:
-          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+      nodeRegistration: {}
     joinConfiguration:
-      nodeRegistration:
-        criSocket: /var/run/containerd/containerd.sock
-        kubeletExtraArgs:
-          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+      nodeRegistration: {}
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -73,5 +69,5 @@ spec:
       name: km-cp-control-plane
       namespace: default
   replicas: 1
-  version: v1.28.0
+  version: v1.28.7
 

--- a/hack/tests/resources/kubemark-machine-deployment-external-cluster.yaml
+++ b/hack/tests/resources/kubemark-machine-deployment-external-cluster.yaml
@@ -29,7 +29,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
         kind: KubemarkMachineTemplate
         name: km-wl-kubemark-external-md-0
-      version: 1.28.0
+      version: 1.28.7
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: KubemarkMachineTemplate

--- a/hack/tests/resources/kubemark-machine-deployment.yaml
+++ b/hack/tests/resources/kubemark-machine-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
         kind: KubemarkMachineTemplate
         name: km-wl-kubemark-md-0
-      version: 1.28.0
+      version: 1.28.7
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: KubemarkMachineTemplate

--- a/templates/cluster-template-capd.yaml
+++ b/templates/cluster-template-capd.yaml
@@ -57,17 +57,12 @@ spec:
       controllerManager:
         extraArgs: {enable-hostpath-provisioner: 'true'}
       apiServer:
-        certSANs: [localhost, 127.0.0.1]
+        # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
+        certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]
     initConfiguration:
-      nodeRegistration:
-        criSocket: unix:///var/run/containerd/containerd.sock
-        kubeletExtraArgs:
-          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+      nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
     joinConfiguration:
-      nodeRegistration:
-        criSocket: unix:///var/run/containerd/containerd.sock
-        kubeletExtraArgs:
-          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+      nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
   version: "${KUBERNETES_VERSION}"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This change modifies the capd control plane template to follow the main cluster-api testing capd template. It mainly updates the nodeRegistration fields now that the capd controller will populate these dynamically.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
