### PR TITLE
update files in preparation for 0.8.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ To run this pipeline docker, kind, python must be installed.
 You can run the E2E test with the following steps:
 
 ```bash
-export KIND_CLUSTER_IMAGE=docker.io/kindest/node:v1.28.0
+export KIND_CLUSTER_IMAGE=docker.io/kindest/node:v1.29.0
 export CAPI_PATH=<path to cluster-api repository>
 export ROOT_DIR=<path to cluster-api-provider-kubemark repository>
 cd $(ROOT_DIR)

--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -2,7 +2,7 @@
   "name": "infrastructure-kubemark",
     "config": {
       "componentsFile": "infrastructure-components.yaml",
-      "nextVersion": "v0.7.99",
+      "nextVersion": "v0.8.99",
       "configFolder": "config"
     }
 }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -23,3 +23,6 @@ releaseSeries:
   - major: 0
     minor: 7
     contract: v1beta1
+  - major: 0
+    minor: 8
+    contract: v1beta1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

updates the metadata files and readme for the 0.8.0 release

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #118 

**Special notes for your reviewer**:

it should be possible to test this manually by using `make test-e2e`, with the cluster-api release-1.7 branch set in the `CAPI_PATH`.

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
