### PR TITLE
prepare repo for 0.9.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ bare-metal machines). It differs significantly in that Kubemark nodes only
 pretend to run pods scheduled to them. For more information on Kubemark, the
 [Kubemark developer guide][kubemark_docs] has more details.
 
+## Supported Versions
+
+| Dependency  | Version |
+|:------------|:-------:|
+| kubernetes  |  v1.31  |
+| cluster-api |  v1.9   |
+
 ## Getting started
 
 **Prerequisites**
@@ -133,20 +140,9 @@ To run this pipeline docker, kind, python must be installed.
 You can run the E2E test with the following steps:
 
 ```bash
-export KIND_CLUSTER_IMAGE=docker.io/kindest/node:v1.29.0
+export KIND_CLUSTER_IMAGE=docker.io/kindest/node:v1.31.0
 export CAPI_PATH=<path to cluster-api repository>
 export ROOT_DIR=<path to cluster-api-provider-kubemark repository>
 cd $(ROOT_DIR)
 make test-e2e
 ```
-
-## Supported Versions
-
-| Dependency  | Version |
-|:------------|:-------:|
-| kubectl     |  v1.29  |
-| kubernetes  |  v1.29  |
-| Go          |  v1.22  |
-| kind        |  v0.17  |
-| cluster-api |  v1.7   |
-| kustomize   |  v4.4   |

--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -2,7 +2,7 @@
   "name": "infrastructure-kubemark",
     "config": {
       "componentsFile": "infrastructure-components.yaml",
-      "nextVersion": "v0.8.99",
+      "nextVersion": "v0.9.99",
       "configFolder": "config"
     }
 }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,3 +26,6 @@ releaseSeries:
   - major: 0
     minor: 8
     contract: v1beta1
+  - major: 0
+    minor: 9
+    contract: v1beta1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fixes up the metadata and readme for the 0.9.0 release.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #129 

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Dependencies updated to Cluster API version 1.9 and Kubernetes version 1.31.
```
