### PR TITLE
Add Metadata kind to metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,6 +4,7 @@
 #
 # update this file only when a new major or minor version is released
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
 releaseSeries:
   - major: 0
     minor: 2


### PR DESCRIPTION
**What type of PR is this?**
/kind support

**What this PR does / why we need it**:
Requirement introduced by https://github.com/kubernetes-sigs/cluster-api/pull/12242 and required by CAPI v1.11 (and thus its clusterctl)

**Release note**:

```release-note
add Metadata kind to metadata
```
